### PR TITLE
Fix Portable Teleporter Crash

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiTeleporter.java
+++ b/src/main/java/mekanism/client/gui/GuiTeleporter.java
@@ -220,7 +220,7 @@ public class GuiTeleporter extends GuiMekanismTile<TileEntityTeleporter> {
         super.mouseClicked(mouseX, mouseY, button);
         updateButtons();
         frequencyField.mouseClicked(mouseX, mouseY, button);
-        if (colorButton.isMouseOver() && button == 1 && tileEntity != null) {
+        if (tileEntity != null && colorButton.isMouseOver() && button == 1) {
             Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, TileNetworkList.withContents(2, 1)));
             SoundHandler.playSound(net.minecraft.init.SoundEvents.UI_BUTTON_CLICK);
         }


### PR DESCRIPTION
编译时由于未知原因导致格式化报错，需要运行一个任务才能修正，会导致大量的文件变更记录，这部分就没提交了